### PR TITLE
Add product descriptions, top-right cart, and apple favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Frukt Finsrud static fruit store
+# Finsrud Frukt static fruit store
 
 This repository contains a simple, multi‑lingual fruit shop for small‑scale farmers.  Customers can browse your current fruit inventory, add items to a shopping cart, review their basket, enter their name and an optional message, and place an order.  After checking out, the site displays a Vipps QR code for payment and sends you an order email via [EmailJS](https://www.emailjs.com/).  Everything runs client‑side, so there’s no need for an expensive app service or Azure Functions.  Host it on any static web host (Azure Storage, GitHub Pages, Netlify, etc.) and use Cloudflare to handle your custom domain and TLS.
 
@@ -74,7 +74,7 @@ This project uses [EmailJS](https://www.emailjs.com/) to send order notification
 3. **Create an email template** under **Email Templates**.  If you would like a bilingual notification, use a subject such as:
 
    ```
-   New fruit order / Ny fruktbestilling – Frukt Finsrud
+   New fruit order / Ny fruktbestilling – Finsrud Frukt
    ```
 
    And paste the following HTML into the template’s HTML tab (you may customise colours and wording).  This template includes your logo at the top, customer name, phone and optional message, a list of the ordered items and the total in both Norwegian and English:
@@ -82,7 +82,7 @@ This project uses [EmailJS](https://www.emailjs.com/) to send order notification
    ```html
    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: auto;">
      <div style="text-align: center; padding: 20px;">
-       <img src="https://finsrudfrukt.z6.web.core.windows.net/images/logo.png" alt="Frukt Finsrud" style="max-height: 80px;">
+       <img src="https://finsrudfrukt.z6.web.core.windows.net/images/logo.png" alt="Finsrud Frukt" style="max-height: 80px;">
        <h2>Fruktbestilling / Fruit Order</h2>
      </div>
      <div style="padding: 20px; background-color: #f9f9f9; border-radius: 8px;">

--- a/data/products.json
+++ b/data/products.json
@@ -5,7 +5,11 @@
     "name": "Plum",
     "variety": "Opal",
     "price": 50,
-    "image": "plums.jpg"
+    "image": "plums.jpg",
+    "description": {
+      "en": "Early ripening plum with sweet, juicy flesh.",
+      "no": "Tidlig modnende plomme med søtt, saftig fruktkjøtt."
+    }
   },
   {
     "id": "plum-victoria",
@@ -13,7 +17,11 @@
     "name": "Plum",
     "variety": "Victoria",
     "price": 55,
-    "image": "plums.jpg"
+    "image": "plums.jpg",
+    "description": {
+      "en": "Classic plum, sweet and great for desserts.",
+      "no": "Klassisk plomme, søt og fin til desserter."
+    }
   },
   {
     "id": "apple-aroma",
@@ -21,7 +29,11 @@
     "name": "Apple",
     "variety": "Aroma",
     "price": 40,
-    "image": "apple.jpg"
+    "image": "apple.jpg",
+    "description": {
+      "en": "Fragrant Norwegian apple with crisp bite.",
+      "no": "Aromatisk norsk eple med sprøtt bitt."
+    }
   },
   {
     "id": "apple-gravenstein",
@@ -29,7 +41,11 @@
     "name": "Apple",
     "variety": "Gravenstein",
     "price": 45,
-    "image": "apple.jpg"
+    "image": "apple.jpg",
+    "description": {
+      "en": "Traditional heritage apple, tart and aromatic.",
+      "no": "Tradisjonelt arveeple, syrlig og aromatisk."
+    }
   }
   ,
   {
@@ -39,6 +55,10 @@
     "variety": "Eplemost",
     "price": 0,
     "image": "apple.jpg",
-    "comingSoon": true
+    "comingSoon": true,
+    "description": {
+      "en": "Freshly pressed apple cider from our orchard.",
+      "no": "Nypresset eplemost fra vår frukthage."
+    }
   }
 ]

--- a/index.html
+++ b/index.html
@@ -3,12 +3,13 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Frukt Finsrud</title>
+  <title>Finsrud Frukt</title>
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍎</text></svg>'">
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
   <header>
-    <h1 id="title">Frukt Finsrud</h1>
+    <h1 id="title">Finsrud Frukt</h1>
     <p id="tagline">Fresh plums and apples from our garden</p>
     <div class="language-switcher">
       <label id="language-label" for="language-select">Language:</label>
@@ -17,6 +18,7 @@
         <option value="en">English</option>
       </select>
     </div>
+    <button id="view-cart-btn" class="cart-button">View Cart</button>
   </header>
   <div class="container">
     <section class="product-section">
@@ -24,7 +26,6 @@
       <div class="product-list">
         <!-- Products will be injected here by JavaScript -->
       </div>
-      <button id="view-cart-btn">View Cart</button>
       <div id="message" class="message" style="display:none;"></div>
     </section>
     <section id="order-summary">

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-/* JavaScript for Frukt Finsrud store */
+/* JavaScript for Finsrud Frukt store */
 
 // EmailJS configuration.  Replace these with your own values from EmailJS.
 // See README for instructions on obtaining your service ID, template ID and public key.
@@ -15,7 +15,7 @@ const EMAILJS_CONFIRM_TEMPLATE_ID = "template_2hxbfa7";
 // Language translations.  Each string in the UI has an entry here for English (en) and Norwegian (no).
 const translations = {
   en: {
-    title: 'Frukt Finsrud',
+    title: 'Finsrud Frukt',
     tagline: 'Fresh plums and apples from our garden',
     productsHeading: 'Our Products',
     pricePerKg: 'Price per kg',
@@ -46,7 +46,7 @@ const translations = {
     ,emailLabel: 'Email (optional)'
   },
   no: {
-    title: 'Frukt Finsrud',
+    title: 'Finsrud Frukt',
     tagline: 'Ferske plommer og epler fra hagen vår',
     productsHeading: 'Våre produkter',
     pricePerKg: 'Pris per kg',
@@ -307,6 +307,7 @@ function loadProducts() {
         <div class="card-content">
           <h3>${translatedName} (${product.variety})</h3>
           <p><em>${translations[currentLanguage].comingSoon}</em></p>
+          ${product.description ? `<p class="product-description">${product.description[currentLanguage]}</p>` : ''}
         </div>
       `;
     } else {
@@ -315,6 +316,7 @@ function loadProducts() {
         <div class="card-content">
           <h3>${translatedName} (${product.variety})</h3>
           <p>${priceText}: <strong>${product.price} NOK</strong></p>
+          ${product.description ? `<p class="product-description">${product.description[currentLanguage]}</p>` : ''}
           <div class="quantity">
             <label for="${product.id}">${kgLabel}:</label>
             <input type="number" id="${product.id}" min="0" step="0.5" value="0">
@@ -444,11 +446,67 @@ let productData = [];
 
 // Fallback products used when products.json cannot be loaded (e.g. when opened via file://)
 const fallbackProducts = [
-  { id: 'plum-opal', category: 'plum', name: 'Plum', variety: 'Opal', price: 50, image: 'plums.jpg' },
-  { id: 'plum-victoria', category: 'plum', name: 'Plum', variety: 'Victoria', price: 55, image: 'plums.jpg' },
-  { id: 'apple-aroma', category: 'apple', name: 'Apple', variety: 'Aroma', price: 40, image: 'apple.jpg' },
-  { id: 'apple-gravenstein', category: 'apple', name: 'Apple', variety: 'Gravenstein', price: 45, image: 'apple.jpg' }
-  , { id: 'eplemost', category: 'juice', name: 'Apple Cider', variety: 'Eplemost', price: 0, image: 'apple.jpg', comingSoon: true }
+  {
+    id: 'plum-opal',
+    category: 'plum',
+    name: 'Plum',
+    variety: 'Opal',
+    price: 50,
+    image: 'plums.jpg',
+    description: {
+      en: 'Early ripening plum with sweet, juicy flesh.',
+      no: 'Tidlig modnende plomme med søtt, saftig fruktkjøtt.'
+    }
+  },
+  {
+    id: 'plum-victoria',
+    category: 'plum',
+    name: 'Plum',
+    variety: 'Victoria',
+    price: 55,
+    image: 'plums.jpg',
+    description: {
+      en: 'Classic plum, sweet and great for desserts.',
+      no: 'Klassisk plomme, søt og fin til desserter.'
+    }
+  },
+  {
+    id: 'apple-aroma',
+    category: 'apple',
+    name: 'Apple',
+    variety: 'Aroma',
+    price: 40,
+    image: 'apple.jpg',
+    description: {
+      en: 'Fragrant Norwegian apple with crisp bite.',
+      no: 'Aromatisk norsk eple med sprøtt bitt.'
+    }
+  },
+  {
+    id: 'apple-gravenstein',
+    category: 'apple',
+    name: 'Apple',
+    variety: 'Gravenstein',
+    price: 45,
+    image: 'apple.jpg',
+    description: {
+      en: 'Traditional heritage apple, tart and aromatic.',
+      no: 'Tradisjonelt arveeple, syrlig og aromatisk.'
+    }
+  },
+  {
+    id: 'eplemost',
+    category: 'juice',
+    name: 'Apple Cider',
+    variety: 'Eplemost',
+    price: 0,
+    image: 'apple.jpg',
+    comingSoon: true,
+    description: {
+      en: 'Freshly pressed apple cider from our orchard.',
+      no: 'Nypresset eplemost fra vår frukthage.'
+    }
+  }
 ];
 
 // Initial page load

--- a/styles.css
+++ b/styles.css
@@ -1,4 +1,4 @@
-/* Basic styling for Frukt Finsrud store */
+/* Basic styling for Finsrud Frukt store */
 
 body {
   font-family: Arial, sans-serif;
@@ -12,6 +12,7 @@ header {
   color: #fff;
   padding: 20px 10px;
   text-align: center;
+  position: relative;
 }
 
 /* Language selector styling */
@@ -96,6 +97,12 @@ header p {
   color: #666;
 }
 
+.product-description {
+  margin-top: 5px;
+  font-size: 0.85rem;
+  color: #444;
+}
+
 .card-content .quantity {
   margin-top: auto;
   display: flex;
@@ -111,15 +118,21 @@ header p {
 
 /* View cart button */
 #view-cart-btn {
-  display: block;
-  margin: 20px auto;
-  padding: 10px 30px;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  margin: 0;
+  padding: 10px 16px;
   font-size: 1rem;
   background-color: #4CAF50;
   color: #fff;
   border: none;
   border-radius: 4px;
   cursor: pointer;
+}
+
+#view-cart-btn::before {
+  content: '🛒 ';
 }
 
 #view-cart-btn:hover {


### PR DESCRIPTION
## Summary
- rename site to Finsrud Frukt and add apple favicon
- move cart button to top-right with shopping cart icon
- provide per-product descriptions in data and UI

## Testing
- `node --version`
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4dace287483258f9cd20d348dbed4