### PR TITLE
Require contact info and default to Norwegian

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="no">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -14,33 +14,33 @@
 <body>
   <header>
     <h1 id="title">Finsrud Frukt</h1>
-    <p id="tagline">Fresh plums and apples from our garden</p>
+    <p id="tagline">Ferske plommer og epler fra hagen vår</p>
     <div class="language-switcher">
-      <label id="language-label" for="language-select">Language:</label>
+      <label id="language-label" for="language-select">Språk:</label>
       <select id="language-select">
-        <option value="no">Norsk</option>
+        <option value="no" selected>Norsk</option>
         <option value="en">English</option>
       </select>
     </div>
   </header>
-  <button id="view-cart-btn" class="cart-button" aria-label="View Cart">
+  <button id="view-cart-btn" class="cart-button" aria-label="Vis handlekurv">
     <i class="fas fa-shopping-cart"></i>
     <span id="cart-count" class="cart-count"></span>
   </button>
   <div class="container">
     <section class="product-section">
-      <h2 id="products-heading">Our Products</h2>
+        <h2 id="products-heading">Våre produkter</h2>
       <div class="product-list">
         <!-- Products will be injected here by JavaScript -->
       </div>
       <div id="message" class="message" style="display:none;"></div>
     </section>
-    <section id="order-summary">
-      <h2 id="order-heading">Your Order</h2>
+      <section id="order-summary">
+        <h2 id="order-heading">Din bestilling</h2>
       <ul>
         <!-- List of ordered items -->
       </ul>
-      <p><strong id="total-label">Total:</strong> <span id="total-amount">0</span> NOK</p>
+        <p><strong id="total-label">Totalt:</strong> <span id="total-amount">0</span> NOK</p>
       <!-- <div id="qr-code">
         <p id="qr-prompt">Scan the VIPPS QR code to pay</p>
         <img src="images/qr.png" alt="Vipps QR Code">
@@ -48,25 +48,25 @@
     </section>
   </div>
   <!-- Shopping cart and checkout section -->
-  <section id="cart-section" style="display:none;">
-    <h2 id="cart-heading">Your Cart</h2>
+    <section id="cart-section" style="display:none;">
+      <h2 id="cart-heading">Din handlekurv</h2>
     <ul id="cart-list">
       <!-- Cart items will be injected here -->
     </ul>
-    <p><strong id="cart-total-label">Total:</strong> <span id="cart-total">0</span> NOK</p>
+      <p><strong id="cart-total-label">Totalt:</strong> <span id="cart-total">0</span> NOK</p>
     <div class="customer-info">
-      <label id="name-label" for="customer-name">Name:</label>
-      <input type="text" id="customer-name">
-      <label id="phone-label" for="customer-phone">Phone (optional):</label>
-      <input type="text" id="customer-phone">
-      <!-- Email field so the customer can receive a confirmation copy -->
-      <label id="email-label" for="customer-email">Email (optional):</label>
-      <input type="email" id="customer-email">
-      <label id="comment-label" for="customer-note">Message (optional):</label>
-      <textarea id="customer-note"></textarea>
-    </div>
-    <button id="checkout-btn">Submit Order</button>
-    <button id="close-cart-btn">Back</button>
+        <label id="name-label" for="customer-name">Navn:</label>
+        <input type="text" id="customer-name">
+        <label id="phone-label" for="customer-phone">Telefon:</label>
+        <input type="tel" id="customer-phone" required>
+        <!-- Email field so the customer can receive a confirmation copy -->
+        <label id="email-label" for="customer-email">E-post:</label>
+        <input type="email" id="customer-email" required>
+        <label id="comment-label" for="customer-note">Melding (valgfritt):</label>
+        <textarea id="customer-note" placeholder="For eksempel: henting på Helgøya, henting i Oslo (Lilleaker eller Økern) eller utkjøring (på forespørsel)"></textarea>
+      </div>
+      <button id="checkout-btn">Send bestilling</button>
+      <button id="close-cart-btn">Tilbake</button>
     <div id="cart-message" class="message" style="display:none;"></div>
   </section>
 

--- a/script.js
+++ b/script.js
@@ -49,13 +49,16 @@ const translations = {
     ,checkout: 'Submit Order'
     ,back: 'Back'
     ,nameLabel: 'Name'
-    ,phoneLabel: 'Phone (optional)'
+    ,phoneLabel: 'Phone'
     ,commentLabel: 'Message (optional)'
     ,cartEmpty: 'Your cart is empty.'
     ,addedToCart: 'Added to cart!'
     ,comingSoon: 'Coming soon'
     ,nameRequired: 'Please enter your name.'
-    ,emailLabel: 'Email (optional)'
+    ,emailLabel: 'Email'
+    ,phoneRequired: 'Please enter your phone number.'
+    ,emailRequired: 'Please enter your email address.'
+    ,commentPlaceholder: 'e.g., pickup at Helgøya, pickup in Oslo (Lilleaker or Økern) or delivery (on request)'
   },
   no: {
     title: 'Finsrud Frukt',
@@ -80,13 +83,16 @@ const translations = {
     ,checkout: 'Send bestilling'
     ,back: 'Tilbake'
     ,nameLabel: 'Navn'
-    ,phoneLabel: 'Telefon (valgfritt)'
+    ,phoneLabel: 'Telefon'
     ,commentLabel: 'Melding (valgfritt)'
     ,cartEmpty: 'Handlekurven er tom.'
     ,addedToCart: 'Lagt i handlekurv!'
     ,comingSoon: 'Kommer snart'
     ,nameRequired: 'Vennligst oppgi navnet ditt.'
-    ,emailLabel: 'E‑post (valgfritt)'
+    ,emailLabel: 'E-post'
+    ,phoneRequired: 'Vennligst oppgi telefonnummer.'
+    ,emailRequired: 'Vennligst oppgi e-postadressen din.'
+    ,commentPlaceholder: 'For eksempel: henting på Helgøya, henting i Oslo (Lilleaker eller Økern) eller utkjøring (på forespørsel)'
   }
 };
 
@@ -97,8 +103,8 @@ const productNameTranslations = {
   , 'Apple Cider': { en: 'Apple Cider', no: 'Eplemost' }
 };
 
-// Current language (defaults to English but is updated on load)
-let currentLanguage = 'en';
+// Current language (defaults to Norwegian but is updated on load)
+let currentLanguage = 'no';
 
 // Shopping cart.  Each entry has { id, name, variety, price, quantity, total }.
 let cart = [];
@@ -194,6 +200,7 @@ function renderCart() {
   const nameLabel = document.getElementById('name-label');
   const phoneLabel = document.getElementById('phone-label');
   const commentLabel = document.getElementById('comment-label');
+  const commentInput = document.getElementById('customer-note');
   const emailLabelEl = document.getElementById('email-label');
   const cartHeading = document.getElementById('cart-heading');
   const cartTotalLabel = document.getElementById('cart-total-label');
@@ -206,6 +213,7 @@ function renderCart() {
   if (nameLabel) nameLabel.textContent = `${translations[currentLanguage].nameLabel}:`;
   if (phoneLabel) phoneLabel.textContent = `${translations[currentLanguage].phoneLabel}:`;
   if (commentLabel) commentLabel.textContent = `${translations[currentLanguage].commentLabel}:`;
+  if (commentInput) commentInput.placeholder = translations[currentLanguage].commentPlaceholder;
   if (emailLabelEl) emailLabelEl.textContent = `${translations[currentLanguage].emailLabel}:`;
   // Clear list
   list.innerHTML = '';
@@ -261,20 +269,21 @@ function submitOrder() {
   const phoneInput = document.getElementById('customer-phone');
   const noteInput = document.getElementById('customer-note');
   const name = nameInput ? nameInput.value.trim() : '';
+  const phone = phoneInput ? phoneInput.value.trim() : '';
   if (!name) {
     alert(translations[currentLanguage].nameRequired);
     return;
   }
   if (!phone) {
-    alert(translations[currentLanguage].phoneRequired || "Vennligst oppgi telefonnummer.");
+    alert(translations[currentLanguage].phoneRequired);
     return;
-  }  
+  }
   const note = noteInput ? noteInput.value.trim() : '';
   // Read email (required)
   const emailInput = document.getElementById('customer-email');
   const email = emailInput ? emailInput.value.trim() : '';
   if (!email) {
-   alert(translations[currentLanguage].emailRequired || "Vennligst oppgi e-postadresse.");
+    alert(translations[currentLanguage].emailRequired);
     return;
   }
   // Populate hidden fields
@@ -603,9 +612,7 @@ window.addEventListener('DOMContentLoaded', async () => {
   if (storedLang) {
     currentLanguage = storedLang;
   } else {
-    // Use browser language: prefer Norwegian if starts with 'no' or 'nb'
-    const navLang = (navigator.language || navigator.userLanguage || '').toLowerCase();
-    currentLanguage = navLang.startsWith('no') || navLang.startsWith('nb') ? 'no' : 'en';
+    currentLanguage = 'no';
     localStorage.setItem('frukt_language', currentLanguage);
   }
   // Set language select value


### PR DESCRIPTION
## Summary
- Make Norwegian the default interface language.
- Require phone number and email in checkout with validation.
- Add cart comment placeholder guiding pickup or delivery options.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a593eef2308325b243bd8e10f9748b