### PR TITLE
Add delivery details to Opal plum description

### DIFF
--- a/data/products.json
+++ b/data/products.json
@@ -12,8 +12,8 @@
       "opal3.jpeg"
     ],
     "description": {
-      "en": "Early ripening plum with sweet, juicy flesh.",
-      "no": "Tidlig modnende plomme med søtt, saftig fruktkjøtt."
+      "en": "Early ripening plum with sweet, juicy flesh. Delivered in baskets of approx. 700 grams.",
+      "no": "Tidlig modnende plomme med søtt, saftig fruktkjøtt. Leveres i kurver på ca. 700 gram."
     }
   },
   {


### PR DESCRIPTION
## Summary
- include basket-weight information in Opal plum description

## Testing
- `python -m json.tool data/products.json`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fc9b26388325a6c0609276642ee9